### PR TITLE
Update microkernel-mod-hapi.js

### DIFF
--- a/microkernel-mod-hapi.js
+++ b/microkernel-mod-hapi.js
@@ -167,7 +167,7 @@ class Module {
                 "method="   + request.method.toUpperCase() + ", " +
                 "url="      + request.url.path + ", " +
                 "protocol=" + protocol + ", " +
-                "response=" + request.response.statusCode +
+                "response=" + (request.response ? request.response.statusCode : "<unknown>") +
                 (kernel.rs("options:options").accounting ?  ", " +
                     "recv="     + traffic.recvPayload + "/" + traffic.recvRaw + ", " +
                     "sent="     + traffic.sentPayload + "/" + traffic.sentRaw + ", " +


### PR DESCRIPTION
request.response can be null when sending streams that abort due to ECONNRESET